### PR TITLE
Use SPDX 3.0 license identifier

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -6,7 +6,7 @@
 	],
 	"url": "http://git-media.wiki",
 	"descriptionmsg": "phpeditor-desc",
-	"license-name": "GPL-2.0+",
+	"license-name": "GPL-3.0-or-later",
 	"type": "other",
 	"MessagesDirs": {
 		"PHPEditor": "i18n"


### PR DESCRIPTION
And all of the files have GPL v3 or later license headers, so
use that as the license identifier.